### PR TITLE
Change profile update route to /profile

### DIFF
--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -10,7 +10,7 @@ const { protect } = require('../middlewares/authMiddleware');
 const router = express.Router();
 
 router.get('/me', protect, getProfile);
-router.put('/me', protect, updateProfile);
+router.put('/profile', protect, updateProfile);
 router.get('/', protect, listUsers); // list public profiles
 router.get('/search', protect, searchUsersBySkill); // ?skill=Photoshop
 


### PR DESCRIPTION
Updated the user profile update endpoint from '/me' to '/profile' for consistency and clarity in the API routes.